### PR TITLE
fix(transactions): support prefix matching in amount column filter

### DIFF
--- a/src/features/transactions/components/TransactionsTable/columns/utils/costFilterFn.ts
+++ b/src/features/transactions/components/TransactionsTable/columns/utils/costFilterFn.ts
@@ -19,8 +19,9 @@ export const costFilterFn: MRT_FilterFn<TransactionTableItem> = (
   if (!value) {
     return false;
   }
+  const normalizedRaw = raw.replace(/^-/, '');
   const costStr = value.cost.abs().toFixed(2);
-  if (costStr.startsWith(raw)) {
+  if (costStr.startsWith(normalizedRaw)) {
     return true;
   }
   let target: Decimal;

--- a/src/features/transactions/components/TransactionsTable/columns/utils/costFilterFn.ts
+++ b/src/features/transactions/components/TransactionsTable/columns/utils/costFilterFn.ts
@@ -15,15 +15,19 @@ export const costFilterFn: MRT_FilterFn<TransactionTableItem> = (
   if (!raw) {
     return true;
   }
+  const value = row.getValue<CostColValue | null>(columnId);
+  if (!value) {
+    return false;
+  }
+  const costStr = value.cost.abs().toFixed(2);
+  if (costStr.startsWith(raw)) {
+    return true;
+  }
   let target: Decimal;
   try {
     target = new Decimal(raw);
   } catch {
     return true;
-  }
-  const value = row.getValue<CostColValue | null>(columnId);
-  if (!value) {
-    return false;
   }
   return value.cost.abs().equals(target.abs());
 };


### PR DESCRIPTION
Closes #140

## What
The amount column filter previously required an exact match — typing `102` would not find a transaction costing €102.54.

Now the filter checks whether the formatted cost string starts with the input, so `1`, `10`, `102`, `102.`, `102.5`, and `102.54` all match €102.54. Exact numeric equality is kept as a fallback so round values like `100` still match `100.00`.

## Verification
- typecheck / lint / format: ✅ pass
- tests: transactions feature has E2E tests but no unit tests for filter functions; no new test layer introduced
- Playwright MCP: opened transactions page on the worktree dev server, confirmed filter input is present in amount column header

## Screenshots
Amount filter in transactions table:
![screenshot](https://raw.githubusercontent.com/BooleT37/finances/pr-screenshots/issue-148/screenshot-148-amount-filter.png)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)