### PR TITLE
fix(budgeting): include 'other' row when filling subscriptions for a category

### DIFF
--- a/src/features/budgeting/components/BudgetingPage/BudgetingTable/columns/collectBulkItems.ts
+++ b/src/features/budgeting/components/BudgetingPage/BudgetingTable/columns/collectBulkItems.ts
@@ -34,7 +34,6 @@ export function collectBulkItems(row: MRT_Row<BudgetingRow>): BulkItem[] {
     const items: BulkItem[] = [];
     for (const subRow of row.subRows ?? []) {
       if (
-        subRow.original.isRestRow ||
         subRow.original.rowType !== 'subcategory' ||
         subRow.original.subscriptions.length === 0
       ) {


### PR DESCRIPTION
Closes #143

## Problem

When clicking "Fill subscriptions" on a category row, the `collectBulkItems` function skipped the "другое" (other/rest) subcategory row due to an `isRestRow` guard. This meant subscriptions attached to that row were never picked up.

## Fix

Removed the `isRestRow ||` condition from the unlocked-category-with-subcategories branch. The downstream `buildUpsertInputs` in `useBulkSaveForecastsSum` already handles rest rows correctly — it adjusts the parent category sum instead of creating a subcategory forecast entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots
Budgeting table with expanded category rows (subscriptions in *другое* row now included):
![screenshot](https://raw.githubusercontent.com/BooleT37/finances/pr-screenshots/issue-150/screenshot-150-rest-row.png)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)