### PR TITLE
feat(statistics): add category icons to comparison chart labels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -781,9 +781,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/src/features/statistics/components/ComparisonChart/ComparisonChart.tsx
+++ b/src/features/statistics/components/ComparisonChart/ComparisonChart.tsx
@@ -1,3 +1,4 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { BarChart } from '@mantine/charts';
 import {
   Alert,
@@ -13,7 +14,9 @@ import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { YAxisTickContentProps } from 'recharts';
 
+import { getIconByValue } from '~/features/categories/components/categoryIcons/categoryIcons';
 import { useSortAllCategoriesById } from '~/features/categories/facets/categoriesOrder';
 import { getCategoryMapQueryOptions } from '~/features/categories/facets/categoryMap';
 import { ISO_DATE_FORMAT } from '~/shared/constants';
@@ -81,6 +84,55 @@ function PeriodPicker({
   );
 }
 
+const CATEGORY_AXIS_WIDTH = 130;
+const CATEGORY_TICK_ICON_SIZE = 12;
+const CATEGORY_TICK_ICON_GAP = 6;
+// Icon + label share a fixed-width slot starting this far left of the tick's
+// anchor point (which sits right at the plot's edge), so the label always
+// starts at the same x regardless of whether its category has an icon.
+const CATEGORY_TICK_BLOCK_START = -(CATEGORY_AXIS_WIDTH - 20);
+
+interface ComparisonYAxisTickProps extends YAxisTickContentProps {
+  categoryIconByShortname: Map<string, string | null>;
+}
+
+function ComparisonYAxisTick({
+  x,
+  y,
+  payload,
+  categoryIconByShortname,
+}: ComparisonYAxisTickProps) {
+  const shortname = String(payload.value);
+  const iconValue = categoryIconByShortname.get(shortname);
+  const icon = iconValue ? getIconByValue(iconValue) : undefined;
+  const textX =
+    CATEGORY_TICK_BLOCK_START +
+    CATEGORY_TICK_ICON_SIZE +
+    CATEGORY_TICK_ICON_GAP;
+
+  return (
+    <g transform={`translate(${x}, ${y})`}>
+      {icon && (
+        // recharts renders axis ticks inside an SVG <g>, not the regular DOM,
+        // so we can't reuse the app's NameWithOptionalIcon (it renders HTML
+        // <span>/<Group>). FontAwesomeIcon itself renders an <svg>, and a
+        // nested <svg> is valid SVG (it opens its own viewport), so we can
+        // position it directly via x/y/width/height like any other SVG node.
+        <FontAwesomeIcon
+          icon={icon}
+          x={CATEGORY_TICK_BLOCK_START}
+          y={-CATEGORY_TICK_ICON_SIZE / 2}
+          width={CATEGORY_TICK_ICON_SIZE}
+          height={CATEGORY_TICK_ICON_SIZE}
+        />
+      )}
+      <text x={textX} y={0} dy={4} fontSize={12} fill="currentColor">
+        {shortname}
+      </text>
+    </g>
+  );
+}
+
 export function ComparisonChart() {
   const { t, i18n } = useTranslation('statistics');
   const [granularity, setGranularity] = useState<Granularity>('month');
@@ -134,12 +186,16 @@ export function ComparisonChart() {
           category.type !== 'TO_SAVINGS' && (showIncome || !category.isIncome)
         );
       })
-      .map((row) => ({
-        categoryId: row.categoryId,
-        category: getOrThrow(categoryMap, row.categoryId, 'Category').shortname,
-        period1: row.period1,
-        period2: row.period2,
-      }))
+      .map((row) => {
+        const category = getOrThrow(categoryMap, row.categoryId, 'Category');
+        return {
+          categoryId: row.categoryId,
+          category: category.shortname,
+          categoryIcon: category.icon,
+          period1: row.period1,
+          period2: row.period2,
+        };
+      })
       .sort((a, b) => {
         if (sortBy === 'category') {
           return sortAllCategoriesById(a.categoryId, b.categoryId);
@@ -147,6 +203,12 @@ export function ComparisonChart() {
         return b[sortBy] - a[sortBy];
       });
   }, [comparisonData, categoryMap, showIncome, sortBy, sortAllCategoriesById]);
+
+  const categoryIconByShortname = useMemo(() => {
+    const map = new Map<string, string | null>();
+    chartData.forEach((row) => map.set(row.category, row.categoryIcon));
+    return map;
+  }, [chartData]);
 
   const period1Label = formatPeriodLabel(granularity, period1, i18n.language);
   const period2Label = formatPeriodLabel(granularity, period2, i18n.language);
@@ -217,6 +279,15 @@ export function ComparisonChart() {
           data={chartData}
           dataKey="category"
           orientation="vertical"
+          yAxisProps={{
+            width: CATEGORY_AXIS_WIDTH,
+            tick: (tickProps: YAxisTickContentProps) => (
+              <ComparisonYAxisTick
+                {...tickProps}
+                categoryIconByShortname={categoryIconByShortname}
+              />
+            ),
+          }}
           series={[
             { name: 'period1', label: period1Label, color: 'blue.6' },
             { name: 'period2', label: period2Label, color: 'orange.6' },

--- a/src/features/statistics/components/ComparisonChart/ComparisonChart.tsx
+++ b/src/features/statistics/components/ComparisonChart/ComparisonChart.tsx
@@ -1,4 +1,4 @@
-import { BarChart } from '@mantine/charts';
+import { BarChart, ChartTooltip } from '@mantine/charts';
 import {
   Alert,
   Group,
@@ -11,10 +11,12 @@ import {
 import { MonthPickerInput, YearPickerInput } from '@mantine/dates';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
-import { useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { YAxisTickContentProps } from 'recharts';
+import type { TooltipPayloadEntry, YAxisTickContentProps } from 'recharts';
 
+import { NameWithOptionalIcon } from '~/features/categories/components/NameWithOptionalIcon';
 import { useSortAllCategoriesById } from '~/features/categories/facets/categoriesOrder';
 import { getCategoryMapQueryOptions } from '~/features/categories/facets/categoryMap';
 import { ISO_DATE_FORMAT } from '~/shared/constants';
@@ -166,6 +168,37 @@ export function ComparisonChart() {
   const period1Label = formatPeriodLabel(granularity, period1, i18n.language);
   const period2Label = formatPeriodLabel(granularity, period2, i18n.language);
 
+  const series = useMemo(
+    () => [
+      { name: 'period1', label: period1Label, color: 'blue.6' },
+      { name: 'period2', label: period2Label, color: 'orange.6' },
+    ],
+    [period1Label, period2Label],
+  );
+
+  const tooltipContent = useCallback(
+    ({
+      label,
+      payload,
+    }: {
+      label?: ReactNode;
+      payload?: readonly TooltipPayloadEntry[];
+    }) => (
+      <ChartTooltip
+        label={
+          <NameWithOptionalIcon
+            name={String(label)}
+            icon={categoryIconByShortname.get(String(label)) ?? null}
+          />
+        }
+        payload={payload}
+        series={series}
+        valueFormatter={(value) => costToString(value)}
+      />
+    ),
+    [categoryIconByShortname, series],
+  );
+
   return (
     <Stack gap="sm">
       <Title order={3}>{t('comparison.title')}</Title>
@@ -241,12 +274,10 @@ export function ComparisonChart() {
               />
             ),
           }}
-          series={[
-            { name: 'period1', label: period1Label, color: 'blue.6' },
-            { name: 'period2', label: period2Label, color: 'orange.6' },
-          ]}
+          series={series}
           valueFormatter={(value) => costToString(value)}
           withLegend
+          tooltipProps={{ content: tooltipContent }}
         />
       )}
     </Stack>

--- a/src/features/statistics/components/ComparisonChart/ComparisonChart.tsx
+++ b/src/features/statistics/components/ComparisonChart/ComparisonChart.tsx
@@ -1,4 +1,3 @@
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { BarChart } from '@mantine/charts';
 import {
   Alert,
@@ -16,7 +15,6 @@ import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { YAxisTickContentProps } from 'recharts';
 
-import { getIconByValue } from '~/features/categories/components/categoryIcons/categoryIcons';
 import { useSortAllCategoriesById } from '~/features/categories/facets/categoriesOrder';
 import { getCategoryMapQueryOptions } from '~/features/categories/facets/categoryMap';
 import { ISO_DATE_FORMAT } from '~/shared/constants';
@@ -24,6 +22,10 @@ import { costToString } from '~/shared/utils/costToString';
 import { getOrThrow } from '~/shared/utils/getOrThrow';
 
 import { getComparisonDataQueryOptions } from '../../queries';
+import {
+  CATEGORY_AXIS_WIDTH,
+  ComparisonYAxisTick,
+} from './ComparisonYAxisTick';
 import {
   formatPeriodLabel,
   type Granularity,
@@ -81,55 +83,6 @@ function PeriodPicker({
       onYearChange={onDateChange}
       onQuarterChange={onQuarterChange}
     />
-  );
-}
-
-const CATEGORY_AXIS_WIDTH = 130;
-const CATEGORY_TICK_ICON_SIZE = 12;
-const CATEGORY_TICK_ICON_GAP = 6;
-// Icon + label share a fixed-width slot starting this far left of the tick's
-// anchor point (which sits right at the plot's edge), so the label always
-// starts at the same x regardless of whether its category has an icon.
-const CATEGORY_TICK_BLOCK_START = -(CATEGORY_AXIS_WIDTH - 20);
-
-interface ComparisonYAxisTickProps extends YAxisTickContentProps {
-  categoryIconByShortname: Map<string, string | null>;
-}
-
-function ComparisonYAxisTick({
-  x,
-  y,
-  payload,
-  categoryIconByShortname,
-}: ComparisonYAxisTickProps) {
-  const shortname = String(payload.value);
-  const iconValue = categoryIconByShortname.get(shortname);
-  const icon = iconValue ? getIconByValue(iconValue) : undefined;
-  const textX =
-    CATEGORY_TICK_BLOCK_START +
-    CATEGORY_TICK_ICON_SIZE +
-    CATEGORY_TICK_ICON_GAP;
-
-  return (
-    <g transform={`translate(${x}, ${y})`}>
-      {icon && (
-        // recharts renders axis ticks inside an SVG <g>, not the regular DOM,
-        // so we can't reuse the app's NameWithOptionalIcon (it renders HTML
-        // <span>/<Group>). FontAwesomeIcon itself renders an <svg>, and a
-        // nested <svg> is valid SVG (it opens its own viewport), so we can
-        // position it directly via x/y/width/height like any other SVG node.
-        <FontAwesomeIcon
-          icon={icon}
-          x={CATEGORY_TICK_BLOCK_START}
-          y={-CATEGORY_TICK_ICON_SIZE / 2}
-          width={CATEGORY_TICK_ICON_SIZE}
-          height={CATEGORY_TICK_ICON_SIZE}
-        />
-      )}
-      <text x={textX} y={0} dy={4} fontSize={12} fill="currentColor">
-        {shortname}
-      </text>
-    </g>
   );
 }
 

--- a/src/features/statistics/components/ComparisonChart/ComparisonYAxisTick.tsx
+++ b/src/features/statistics/components/ComparisonChart/ComparisonYAxisTick.tsx
@@ -1,0 +1,54 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { YAxisTickContentProps } from 'recharts';
+
+import { getIconByValue } from '~/features/categories/components/categoryIcons/categoryIcons';
+
+export const CATEGORY_AXIS_WIDTH = 130;
+
+const CATEGORY_TICK_ICON_SIZE = 12;
+const CATEGORY_TICK_ICON_GAP = 6;
+// Icon + label share a fixed-width slot starting this far left of the tick's
+// anchor point (which sits right at the plot's edge), so the label always
+// starts at the same x regardless of whether its category has an icon.
+const CATEGORY_TICK_BLOCK_START = -(CATEGORY_AXIS_WIDTH - 20);
+
+interface Props extends YAxisTickContentProps {
+  categoryIconByShortname: Map<string, string | null>;
+}
+
+export function ComparisonYAxisTick({
+  x,
+  y,
+  payload,
+  categoryIconByShortname,
+}: Props) {
+  const shortname = String(payload.value);
+  const iconValue = categoryIconByShortname.get(shortname);
+  const icon = iconValue ? getIconByValue(iconValue) : undefined;
+  const textX =
+    CATEGORY_TICK_BLOCK_START +
+    CATEGORY_TICK_ICON_SIZE +
+    CATEGORY_TICK_ICON_GAP;
+
+  return (
+    <g transform={`translate(${x}, ${y})`}>
+      {icon && (
+        // recharts renders axis ticks inside an SVG <g>, not the regular DOM,
+        // so we can't reuse the app's NameWithOptionalIcon (it renders HTML
+        // <span>/<Group>). FontAwesomeIcon itself renders an <svg>, and a
+        // nested <svg> is valid SVG (it opens its own viewport), so we can
+        // position it directly via x/y/width/height like any other SVG node.
+        <FontAwesomeIcon
+          icon={icon}
+          x={CATEGORY_TICK_BLOCK_START}
+          y={-CATEGORY_TICK_ICON_SIZE / 2}
+          width={CATEGORY_TICK_ICON_SIZE}
+          height={CATEGORY_TICK_ICON_SIZE}
+        />
+      )}
+      <text x={textX} y={0} dy={4} fontSize={12} fill="currentColor">
+        {shortname}
+      </text>
+    </g>
+  );
+}


### PR DESCRIPTION
Closes #161

## What
The category labels on the Statistics comparison chart didn't show category icons, unlike other places in the app. The issue allowed skipping if this proved too complex given the charting library — it turned out feasible.

Unlike the dynamics chart's legend (a DOM-rendered element, fixed via `legendProps.content` in #165), this chart's category labels are the **Y-axis tick labels**, which live in recharts' SVG coordinate space, not the DOM — so the existing `NameWithOptionalIcon` (which renders HTML `span`/`Group`) can't be reused directly.

Implemented a custom Y-axis tick renderer (`ComparisonYAxisTick`) that nests `FontAwesomeIcon`'s own `<svg>` inside the tick's `<g>` (a nested `<svg>` is valid SVG — it opens its own viewport), positioned via explicit `x`/`y`/`width`/`height`, with a fixed-width reserved icon+gap slot so labels align consistently whether or not a category has an icon. Wired via `yAxisProps={{ tick: ... }}` on the `BarChart`.

## Verification
- typecheck / lint / format: pass
- tests: no existing tests target `ComparisonChart` or `statistics` UI (only data-aggregation unit tests for the feature) — no new test layer introduced
- Playwright MCP: logged into a throwaway local dev account, created categories with icons and transactions across two comparison periods, confirmed each Y-axis label renders its icon next to the category name, correctly aligned across multiple rows

## Screenshots
![after](https://raw.githubusercontent.com/BooleT37/finances/pr-screenshots/issue-161/after.png)

🤖 Generated with autonomous AI issue implementation