### PR TITLE
feat(auth): add language switcher to the login page

### DIFF
--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,4 +1,12 @@
-import { Box, Center, Divider, Paper, Stack, Title } from '@mantine/core';
+import {
+  Box,
+  Center,
+  Divider,
+  Group,
+  Paper,
+  Stack,
+  Title,
+} from '@mantine/core';
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -42,9 +50,18 @@ function LoginPage() {
 
   return (
     <Box pos="relative" h="100vh">
-      <Box pos="absolute" top="md" right="md">
+      <Group
+        h={40}
+        px="md"
+        justify="flex-end"
+        align="center"
+        pos="absolute"
+        top={0}
+        right={0}
+        left={0}
+      >
         <LanguageSwitcher />
-      </Box>
+      </Group>
       <Center h="100%">
         <Paper withBorder p="xl" w={360}>
           <Stack gap="lg">

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,8 +1,9 @@
-import { Center, Divider, Paper, Stack, Title } from '@mantine/core';
+import { Box, Center, Divider, Paper, Stack, Title } from '@mantine/core';
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
+import { LanguageSwitcher } from '~/components/LanguageSwitcher';
 import { fetchSession } from '~/features/auth/api';
 import { GoogleSignInButton } from '~/features/auth/components/GoogleSignInButton';
 import { LoginForm } from '~/features/auth/components/LoginForm';
@@ -40,17 +41,22 @@ function LoginPage() {
   }
 
   return (
-    <Center h="100vh">
-      <Paper withBorder p="xl" w={360}>
-        <Stack gap="lg">
-          <Title order={2} ta="center">
-            {t('pageTitle')}
-          </Title>
-          <LoginForm onSuccess={handleSuccess} />
-          <Divider label={t('form.or')} />
-          <GoogleSignInButton callbackURL={redirectTo} />
-        </Stack>
-      </Paper>
-    </Center>
+    <Box pos="relative" h="100vh">
+      <Box pos="absolute" top="md" right="md">
+        <LanguageSwitcher />
+      </Box>
+      <Center h="100%">
+        <Paper withBorder p="xl" w={360}>
+          <Stack gap="lg">
+            <Title order={2} ta="center">
+              {t('pageTitle')}
+            </Title>
+            <LoginForm onSuccess={handleSuccess} />
+            <Divider label={t('form.or')} />
+            <GoogleSignInButton callbackURL={redirectTo} />
+          </Stack>
+        </Paper>
+      </Center>
+    </Box>
   );
 }

--- a/test/e2e/auth/login.spec.ts
+++ b/test/e2e/auth/login.spec.ts
@@ -49,4 +49,22 @@ test.describe('login', () => {
     await page.goto('/transactions');
     await expect(page).toHaveURL(/\/login/);
   });
+
+  test('language switcher changes the page language', async ({
+    page,
+    context,
+  }) => {
+    await context.clearCookies();
+    await page.goto('/login');
+    await expect(page.getByText('Вход', { exact: true })).toBeVisible();
+
+    await page
+      .getByLabel('Language switcher')
+      .locator('input[value="en"]')
+      .dispatchEvent('click');
+
+    await expect(
+      page.getByRole('heading', { name: 'Sign in', exact: true }),
+    ).toBeVisible();
+  });
 });


### PR DESCRIPTION
Closes #162

## What
The login page had no way to switch language before signing in — the app always initialized in Russian on that page, with no way to change it until after signing in. Reused the existing `LanguageSwitcher` component (already used in the app header), pinned to the top-right corner of the login page.

## Verification
- typecheck / lint / format: pass
- tests: added a case to `test/e2e/auth/login.spec.ts` verifying the switcher changes the page language; full login suite (4 tests) passes
- Playwright MCP: signed out to reach the login page, confirmed the switcher renders top-right, and clicking "EN" switches the page (title, heading, form labels, buttons) to English

## Screenshots
![ru](https://raw.githubusercontent.com/BooleT37/finances/pr-screenshots/issue-162/ru.png)
![en](https://raw.githubusercontent.com/BooleT37/finances/pr-screenshots/issue-162/en.png)

🤖 Generated with autonomous AI issue implementation