### PR TITLE
feat(nav): show user's display name instead of email in header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -781,9 +781,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/src/features/nav/components/AppHeader.tsx
+++ b/src/features/nav/components/AppHeader.tsx
@@ -54,7 +54,7 @@ export function AppHeader() {
 
       <Group gap="sm">
         <Text size="sm" c="dimmed">
-          {session.email}
+          {session.name}
         </Text>
         <LanguageSwitcher />
         <Tooltip label={t('signOut')}>


### PR DESCRIPTION
Closes #174

## What
The top-right header (`AppHeader.tsx`) showed the signed-in user's email. It now shows their display name (`session.name`) instead — the session object already carried both `email` and `name` from `fetchSession`, so this is a one-line swap at the single call site rendering it. No other place reads `session.email` for display purposes, so nothing else needed to change.

## Verification
- typecheck / lint / format: pass
- tests: no existing e2e spec asserts the header's email/name text, and per the task scope this bite-sized change doesn't introduce a new test layer. Manually verified instead.
- Playwright MCP: signed in as a local test user (name "AI Verify", email `ai-verify@local.test`) and confirmed the header shows "AI Verify" rather than the email.

## Screenshots
![after](https://raw.githubusercontent.com/BooleT37/finances/pr-screenshots/issue-174/after.png)