### PR TITLE
fix(transactions): fill transactions table cell with inline name edit input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -781,9 +781,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/src/shared/components/EditableCellInput.tsx
+++ b/src/shared/components/EditableCellInput.tsx
@@ -46,6 +46,7 @@ export function EditableCellInput({
         }
       }}
       error={invalid}
+      style={{ flex: 1 }}
       styles={{
         input: invalid
           ? { backgroundColor: 'var(--mantine-color-red-0)' }


### PR DESCRIPTION
Closes #175

## What
`EditableCellInput`'s `TextInput` had no explicit sizing. In the transactions table's name column, the `Edit` render wraps it in a `Group` (`wrap="nowrap"`) alongside the row-expand button. As a flex item with default `width: auto`, the input shrank to its content width instead of filling the remaining flex space, leaving a visible gap before the cell's right edge.

Fix: `style={{ flex: 1 }}` on the `TextInput`. This makes it grow to fill the remaining space in a flex row (the name-cell case), and is a no-op where `EditableCellInput` renders directly inside a table `<td>` (e.g. the cost column) — that's a plain block box which already fills its container by default, so nothing changes there.

`EditableCellInput` is shared across features, so this fixes every table that uses the same `Group`-wrapped name-cell pattern:
- **Transactions** — name cell (bug as reported) — verified before/after via screenshots.
- **Categories** — name cell, same `Group` wrapping pattern — verified visually, input now fills the cell, no regression.
- **Subscriptions** — name cell, same pattern (`SubscriptionNameCellEdit`) — no seed data available to click through in this environment, but the render code is textually identical to the categories case, so the same fix applies. `SubscriptionPriceCellEdit` (like the transactions cost cell) renders directly in a `<td>`, unaffected.

No behavior change — this is CSS/layout only.

## Verification
- `npm run typecheck && npm run lint && npm run format:check` — all pass
- Existing e2e coverage: `test/e2e/transactions.spec.ts` → "Inline cell editing" describe block already exercises name/cost/date/source inline edits end-to-end (save behavior). This bug is purely visual/layout (the input already saved correctly before the fix), and the existing suite has no bounding-box/computed-style assertions anywhere, so I didn't bolt one on as a one-off — verified instead via Playwright screenshots (below) and direct DOM geometry measurements during development (input's right edge now matches the flex container's right edge exactly, vs. a ~9px gap before the fix).
- Playwright: navigated to the transactions table, clicked into inline name edit on a real row, confirmed input renders full-width; repeated on the categories table for regression-checking the shared component.

## Screenshots
Before (gap between input and cell edge):
![before](https://raw.githubusercontent.com/BooleT37/finances/pr-screenshots/issue-175/before.png)

After (input fills the cell):
![after](https://raw.githubusercontent.com/BooleT37/finances/pr-screenshots/issue-175/after.png)