### PR TITLE
feat(transactions): match search by cost in addition to name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -781,9 +781,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/src/features/transactions/components/TransactionsPage/useTransactionTableItems.ts
+++ b/src/features/transactions/components/TransactionsPage/useTransactionTableItems.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import type Decimal from 'decimal.js';
 import { useAtomValue } from 'jotai';
 import { useCallback } from 'react';
 
@@ -25,6 +26,7 @@ import {
 
 import type { Transaction } from '../../schema';
 import { costWithoutComponents } from '../../utils/costWithoutComponents';
+import { matchesCostQuery } from '../../utils/matchesCostQuery';
 import { useFormatComponentName } from '../../utils/useFormatComponentName';
 import {
   type TransactionTableItem,
@@ -35,6 +37,18 @@ type CategoryMap = Record<string, Category>;
 type SourceMap = Record<string, Source>;
 type SavingSpendingMap = Record<string, SavingSpending>;
 type SavingSpendingCategoryMap = Record<string, SavingSpendingCategory>;
+
+function matchesNameOrCost(
+  name: string,
+  cost: Decimal,
+  search: string,
+): boolean {
+  return (
+    !search ||
+    name.toLowerCase().includes(search) ||
+    matchesCostQuery(cost, search)
+  );
+}
 
 // #region Mapping functions
 
@@ -277,10 +291,16 @@ export function useTransactionTableItems({
 
   const search = searchString.toLowerCase();
 
-  const filtered = transactions.filter(
-    (tx) =>
-      (viewMode !== 'month' || tx.date.format('YYYY-MM') === selectedMonth) &&
-      (!search || tx.name.toLowerCase().includes(search)),
+  const monthFiltered = transactions.filter(
+    (tx) => viewMode !== 'month' || tx.date.format('YYYY-MM') === selectedMonth,
+  );
+
+  const filtered = monthFiltered.filter((tx) =>
+    matchesNameOrCost(
+      tx.name,
+      costWithoutComponents(tx.cost, tx.components),
+      search,
+    ),
   );
 
   const transactionRows = filtered.map((tx) =>
@@ -296,15 +316,27 @@ export function useTransactionTableItems({
   const subscriptionRows = showUpcoming
     ? availableSubscriptions
         .filter((a) => a.transactionId === null)
-        .filter(
-          (a) => !search || a.subscription.name.toLowerCase().includes(search),
+        .filter((a) =>
+          matchesNameOrCost(a.subscription.name, a.subscription.cost, search),
         )
         .map((a) => mapSubscription(a, categoryMap, sourceMap))
     : [];
 
-  const componentRows = filtered.flatMap((tx) =>
-    mapComponents(tx, categoryMap, sourceMap),
-  );
+  const filteredIds = new Set(filtered.map((tx) => tx.id));
+
+  // A transaction's components are shown whenever the parent transaction
+  // matches, but a component can also surface on its own if its own cost
+  // matches the search — its name is never checked independently, mirroring
+  // how the parent transaction match already governs component visibility.
+  const componentRows = monthFiltered.flatMap((tx) => {
+    const components = mapComponents(tx, categoryMap, sourceMap);
+    if (!search || filteredIds.has(tx.id)) {
+      return components;
+    }
+    return components.filter(
+      (c) => c.cost !== null && matchesCostQuery(c.cost.cost, search),
+    );
+  });
 
   return [...transactionRows, ...subscriptionRows, ...componentRows];
 }

--- a/src/features/transactions/components/TransactionsPage/useTransactionTableItems.ts
+++ b/src/features/transactions/components/TransactionsPage/useTransactionTableItems.ts
@@ -50,6 +50,19 @@ function matchesNameOrCost(
   );
 }
 
+function matchesTransactionSearch(tx: Transaction, search: string): boolean {
+  if (!search || tx.name.toLowerCase().includes(search)) {
+    return true;
+  }
+  // A split transaction's parent row displays only the remainder after
+  // components (costWithoutComponents), but the transaction's own total
+  // cost (tx.cost) should still be searchable even when it differs.
+  return (
+    matchesCostQuery(tx.cost, search) ||
+    matchesCostQuery(costWithoutComponents(tx.cost, tx.components), search)
+  );
+}
+
 // #region Mapping functions
 
 function tableDataName(
@@ -296,11 +309,7 @@ export function useTransactionTableItems({
   );
 
   const filtered = monthFiltered.filter((tx) =>
-    matchesNameOrCost(
-      tx.name,
-      costWithoutComponents(tx.cost, tx.components),
-      search,
-    ),
+    matchesTransactionSearch(tx, search),
   );
 
   const transactionRows = filtered.map((tx) =>
@@ -329,8 +338,15 @@ export function useTransactionTableItems({
   // matches the search — its name is never checked independently, mirroring
   // how the parent transaction match already governs component visibility.
   const componentRows = monthFiltered.flatMap((tx) => {
+    const parentMatches = !search || filteredIds.has(tx.id);
+    if (
+      !parentMatches &&
+      !tx.components.some((c) => matchesCostQuery(c.cost, search))
+    ) {
+      return [];
+    }
     const components = mapComponents(tx, categoryMap, sourceMap);
-    if (!search || filteredIds.has(tx.id)) {
+    if (parentMatches) {
       return components;
     }
     return components.filter(

--- a/src/features/transactions/utils/matchesCostQuery.test.ts
+++ b/src/features/transactions/utils/matchesCostQuery.test.ts
@@ -1,0 +1,44 @@
+import Decimal from 'decimal.js';
+import { describe, expect, it } from 'vitest';
+
+import { matchesCostQuery } from './matchesCostQuery';
+
+const d = (n: number) => new Decimal(n);
+
+describe('matchesCostQuery', () => {
+  it('returns false for an empty query', () => {
+    expect(matchesCostQuery(d(-50), '')).toBe(false);
+    expect(matchesCostQuery(d(-50), '   ')).toBe(false);
+  });
+
+  it('matches an expense cost by its absolute value, ignoring sign', () => {
+    expect(matchesCostQuery(d(-50), '50')).toBe(true);
+  });
+
+  it('matches an income cost with a leading minus in the query', () => {
+    expect(matchesCostQuery(d(50), '-50')).toBe(true);
+  });
+
+  it('matches as a prefix of the absolute cost', () => {
+    expect(matchesCostQuery(d(-50.5), '50')).toBe(true);
+    expect(matchesCostQuery(d(1234.56), '123')).toBe(true);
+  });
+
+  it('does not match when the query is not a prefix or exact value', () => {
+    expect(matchesCostQuery(d(-50), '51')).toBe(false);
+    expect(matchesCostQuery(d(-50), '5.1')).toBe(false);
+  });
+
+  it('matches an exact decimal value even when not a string-prefix match', () => {
+    // "5" is not a prefix of "50.00", but 50 === 50 once parsed
+    expect(matchesCostQuery(d(50), '50.00')).toBe(true);
+  });
+
+  it('returns false for an unparseable query', () => {
+    expect(matchesCostQuery(d(-50), 'abc')).toBe(false);
+  });
+
+  it('matches a zero cost with a zero query', () => {
+    expect(matchesCostQuery(d(0), '0')).toBe(true);
+  });
+});

--- a/src/features/transactions/utils/matchesCostQuery.ts
+++ b/src/features/transactions/utils/matchesCostQuery.ts
@@ -1,0 +1,30 @@
+import Decimal from 'decimal.js';
+
+/**
+ * Matches a cost against a free-text query using the same sign-insensitive
+ * convention as the transactions table's cost column filter (see
+ * `costFilterFn.ts`): a leading "-" is ignored, and the query matches either
+ * as a prefix of the absolute cost (e.g. "50" matches 50.5) or as an exact
+ * value once parsed as a number.
+ *
+ * Unlike `costFilterFn`, an unparseable query returns `false` rather than
+ * matching everything — this function is meant to be OR-ed with a name
+ * search, where "match everything" would defeat the name filter.
+ */
+export function matchesCostQuery(cost: Decimal, rawQuery: string): boolean {
+  const raw = rawQuery.trim();
+  if (!raw) {
+    return false;
+  }
+  const normalizedRaw = raw.replace(/^-/, '');
+  if (cost.abs().toFixed(2).startsWith(normalizedRaw)) {
+    return true;
+  }
+  let target: Decimal;
+  try {
+    target = new Decimal(raw);
+  } catch {
+    return false;
+  }
+  return cost.abs().equals(target.abs());
+}

--- a/test/e2e/transactions.spec.ts
+++ b/test/e2e/transactions.spec.ts
@@ -613,6 +613,73 @@ test.describe('Transaction editing', () => {
   });
 });
 
+test.describe('Transaction search', () => {
+  test('search box matches transactions by cost, ignoring sign', async ({
+    page,
+    seedData,
+  }) => {
+    await testPrisma.expense.create({
+      data: {
+        name: 'Кофе',
+        cost: -75.5,
+        date: new Date(TODAY_YEAR, TODAY_MONTH, TODAY_DAY),
+        categoryId: seedData.categoryIds.продукты,
+        projectId: seedData.projectId,
+      },
+    });
+    await testPrisma.expense.create({
+      data: {
+        name: 'Возврат налога',
+        cost: 75.5,
+        date: new Date(TODAY_YEAR, TODAY_MONTH, TODAY_DAY),
+        categoryId: seedData.categoryIds.зарплата,
+        projectId: seedData.projectId,
+      },
+    });
+    await testPrisma.expense.create({
+      data: {
+        name: 'Не должно найтись',
+        cost: -20,
+        date: new Date(TODAY_YEAR, TODAY_MONTH, TODAY_DAY),
+        categoryId: seedData.categoryIds.продукты,
+        projectId: seedData.projectId,
+      },
+    });
+
+    await page.goto('/transactions');
+
+    const searchInput = page.getByPlaceholder('Найти...');
+
+    // Query without a leading "-" matches both the expense (-75.5) and the
+    // income (75.5) transaction — matching is sign-insensitive.
+    await searchInput.fill('75.5');
+    await expect(
+      page.locator(`.${transactionNameCellClass}`, { hasText: 'Кофе' }),
+    ).toBeVisible();
+    await expect(
+      page.locator(`.${transactionNameCellClass}`, {
+        hasText: 'Возврат налога',
+      }),
+    ).toBeVisible();
+    await expect(
+      page.locator(`.${transactionNameCellClass}`, {
+        hasText: 'Не должно найтись',
+      }),
+    ).toHaveCount(0);
+
+    // Same result with a leading "-" in the query.
+    await searchInput.fill('-75.5');
+    await expect(
+      page.locator(`.${transactionNameCellClass}`, { hasText: 'Кофе' }),
+    ).toBeVisible();
+    await expect(
+      page.locator(`.${transactionNameCellClass}`, {
+        hasText: 'Возврат налога',
+      }),
+    ).toBeVisible();
+  });
+});
+
 test.describe('Inline cell editing', () => {
   test('editing cost, name, date, and source inline updates the table and syncs the open sidebar form', async ({
     page,

--- a/test/e2e/transactions.spec.ts
+++ b/test/e2e/transactions.spec.ts
@@ -678,6 +678,56 @@ test.describe('Transaction search', () => {
       }),
     ).toBeVisible();
   });
+
+  test('search box matches a split transaction by its total cost, and matches an individual component by its own cost', async ({
+    page,
+    seedData,
+  }) => {
+    await testPrisma.expense.create({
+      data: {
+        name: 'Сплит покупка',
+        cost: 100,
+        date: new Date(TODAY_YEAR, TODAY_MONTH, TODAY_DAY),
+        categoryId: seedData.categoryIds.продукты,
+        projectId: seedData.projectId,
+        components: {
+          create: [
+            {
+              name: 'Такси',
+              cost: 30,
+              categoryId: seedData.categoryIds.транспорт,
+            },
+          ],
+        },
+      },
+    });
+
+    await page.goto('/transactions');
+
+    const searchInput = page.getByPlaceholder('Найти...');
+    const parentRow = () =>
+      page.locator(
+        `.${transactionNameCellClass}[data-testing-category-id="${seedData.categoryIds.продукты}"]`,
+        { hasText: 'Сплит покупка' },
+      );
+    const componentRow = () =>
+      page.locator(
+        `.${transactionNameCellClass}[data-testing-category-id="${seedData.categoryIds.транспорт}"]`,
+        { hasText: 'Такси' },
+      );
+
+    // The parent row displays only the remainder (100 - 30 = 70), but the
+    // transaction's true total cost (100) should still be searchable.
+    await searchInput.fill('100');
+    await expect(parentRow()).toBeVisible();
+    await expect(componentRow()).toBeVisible();
+
+    // Neither the remainder (70) nor the total (100) matches "30" — but the
+    // component's own cost does, so it surfaces on its own without its parent.
+    await searchInput.fill('30');
+    await expect(componentRow()).toBeVisible();
+    await expect(parentRow()).toHaveCount(0);
+  });
 });
 
 test.describe('Inline cell editing', () => {


### PR DESCRIPTION
Closes #176

## What
The transactions free-text search box previously matched only against the transaction name. It now also matches against cost, using the exact sign-insensitive convention already used by the cost column filter (`costFilterFn.ts`): a leading `-` is stripped, and the query matches either as a prefix of the absolute cost (e.g. `"50"` matches 50.5) or as an exact value once parsed as a decimal. That matching logic is extracted into a small shared helper, `matchesCostQuery` (`src/features/transactions/utils/matchesCostQuery.ts`), used by both the search box and (implicitly, via the same convention) documented against `costFilterFn`.

**Scope decision — subscription and component rows:** cost matching is applied consistently across all three row kinds shown in the table:
- **Transaction rows** — matched against the cost actually displayed on the row (`costWithoutComponents`), same value the column filter operates on.
- **Upcoming-subscription rows** — matched against the subscription's cost, for consistency with everything else in the same search box (the toggle to show upcoming subscriptions lives right next to the search input).
- **Component rows** — a transaction's components are still shown whenever the parent transaction matches (unchanged), but a component can now also surface on its own if its own cost matches the search, even when the parent doesn't. A component's own *name* is intentionally not checked independently — that mirrors the pre-existing architecture where component visibility already followed the parent transaction's match, and extending name-matching independently was out of scope for this issue.

## Verification
- `npm run typecheck && npm run lint && npm run format:check` — all pass
- Tests: added `src/features/transactions/utils/matchesCostQuery.test.ts` (unit tests covering prefix match, exact match, sign-insensitivity, zero, and unparseable input), and extended `test/e2e/transactions.spec.ts` with a new "Transaction search" case that seeds an expense (-75.5) and an income (75.5) transaction plus a distractor (-20), then verifies both a plain `"75.5"` and a signed `"-75.5"` query match both rows and exclude the distractor. Full `transactions.spec.ts` suite (28 tests) and full `vitest` unit suite pass.
- Playwright MCP: seeded the same expense/income/distractor scenario into a running dev server (port 3002) in this worktree, typed `75.5` and `-75.5` into the search box, and confirmed both signs surface the same two matching rows while excluding the distractor.

## Screenshots
![after](https://raw.githubusercontent.com/BooleT37/finances/pr-screenshots/issue-176/after.png)