### PR TITLE
fix(budgeting): stop selected month from syncing live across tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -781,9 +781,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/src/stores/month.ts
+++ b/src/stores/month.ts
@@ -1,12 +1,25 @@
 import { atom } from 'jotai';
-import { atomWithStorage } from 'jotai/utils';
+import { atomWithStorage, createJSONStorage } from 'jotai/utils';
 
 import { getToday } from '~/shared/utils/today';
 
-/** Selected month stored as 'YYYY-MM', e.g. '2026-02'. Persisted to localStorage. */
+/**
+ * Same as the default JSON storage, minus `subscribe`. The default `subscribe`
+ * listens for the browser `storage` event and pushes changes made in other tabs
+ * into this atom, which would sync the selected month live across tabs. The
+ * selected month should persist to localStorage (so a reload remembers it) but
+ * stay per-tab, so cross-tab pushes are dropped here.
+ */
+const selectedMonthStorage = {
+  ...createJSONStorage<string>(),
+  subscribe: undefined,
+};
+
+/** Selected month stored as 'YYYY-MM', e.g. '2026-02'. Persisted to localStorage, per-tab only. */
 export const selectedMonthKeyAtom = atomWithStorage(
   'finances.selectedMonth',
   getToday().format('YYYY-MM'),
+  selectedMonthStorage,
 );
 
 /** Derived: numeric year from selectedMonthKeyAtom, e.g. 2026 */

--- a/src/stores/month.ts
+++ b/src/stores/month.ts
@@ -3,15 +3,9 @@ import { atomWithStorage, createJSONStorage } from 'jotai/utils';
 
 import { getToday } from '~/shared/utils/today';
 
-/**
- * Same as the default JSON storage, minus `subscribe`. The default `subscribe`
- * listens for the browser `storage` event and pushes changes made in other tabs
- * into this atom, which would sync the selected month live across tabs. The
- * selected month should persist to localStorage (so a reload remembers it) but
- * stay per-tab, so cross-tab pushes are dropped here.
- */
 const selectedMonthStorage = {
   ...createJSONStorage<string>(),
+  // Drop subscribing to local storage changes to keep storage per-tab
   subscribe: undefined,
 };
 

--- a/test/e2e/home.spec.ts
+++ b/test/e2e/home.spec.ts
@@ -68,6 +68,35 @@ test.describe('App shell', () => {
   });
 });
 
+test.describe('Month navigator cross-tab behavior', () => {
+  test('changing the month in one tab does not affect another tab, but persists on reload', async ({
+    page,
+    context,
+  }) => {
+    await page.goto('/transactions');
+
+    const monthLabel = page.getByRole('button', { name: 'Апрель 2024' });
+    await expect(monthLabel).toBeVisible();
+
+    const page2 = await context.newPage();
+    await page2.goto('/transactions');
+    await page2.waitForLoadState('networkidle');
+    const monthLabel2 = page2.getByRole('button', { name: 'Апрель 2024' });
+    await expect(monthLabel2).toBeVisible();
+
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page.getByRole('button', { name: 'Май 2024' })).toBeVisible();
+
+    await expect(monthLabel2).toBeVisible();
+
+    await page2.goto('/transactions');
+    await page2.waitForLoadState('networkidle');
+    await expect(page2.getByRole('button', { name: 'Май 2024' })).toBeVisible();
+
+    await page2.close();
+  });
+});
+
 test.describe('Language prefill from browser locale', () => {
   test.use({ locale: 'en-US' });
 


### PR DESCRIPTION
Closes #177

## What
`selectedMonthKeyAtom` (`src/stores/month.ts`) is a jotai `atomWithStorage`. When called without an explicit storage argument, jotai defaults to `createJSONStorage()`, whose default storage object includes a `subscribe` that listens for the browser's `storage` event and pushes localStorage changes made in *other* tabs into the atom — that's what caused the month to sync live across all open tabs.

Fix: pass an explicit storage object that spreads `createJSONStorage<string>()` (same `getItem`/`setItem`/`removeItem`, so persistence to and read-back from localStorage is unchanged) but overrides `subscribe: undefined`, dropping the cross-tab push. `viewModeAtom` (the month/year toggle) was left untouched — the issue is scoped to the selected month only.

## Verification
- typecheck / lint / format: pass
- tests: added an E2E case in `test/e2e/home.spec.ts` ("Month navigator cross-tab behavior") — two pages in the same browser context (shares localStorage like real tabs), changes the month in one, asserts the other's displayed month is unaffected, then reloads the second page and asserts it now shows the new month. Verified the test fails without the fix (reproduces the original bug) and passes with it. Placed in `home.spec.ts` (app-shell/nav level) rather than under `test/e2e/budgeting/`, since `MonthNavigator` is shared nav infrastructure, not budgeting-specific — `home.spec.ts` already covers other cross-cutting nav behavior (visibility, language switcher persistence).
- Playwright (real Chromium, via the project's Playwright test harness with two pages in one browser context, which is how tabs share localStorage): opened two tabs on `/transactions`, changed the month in tab 1 (Next button), confirmed tab 2 stayed on the old month, then reloaded tab 2 and confirmed it picked up the new persisted month.

## Screenshots
Tab 1 after clicking Next (now on Май 2024):
![tab1-after](https://raw.githubusercontent.com/BooleT37/finances/pr-screenshots/issue-177/tab1-after.png)

Tab 2 immediately after (still on Апрель 2024 — no live sync):
![tab2-after](https://raw.githubusercontent.com/BooleT37/finances/pr-screenshots/issue-177/tab2-after.png)

Tab 2 after reload (now shows Май 2024 — persistence still works):
![tab2-after-reload](https://raw.githubusercontent.com/BooleT37/finances/pr-screenshots/issue-177/tab2-after-reload.png)